### PR TITLE
Add validation to croud-forms

### DIFF
--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="ui field" :class="inputClasses">
+        <label>{{ field.field_name }}</label>
+        <div class="" v-for="(val, $key) in validation" v-if="validation.$dirty && !$key.startsWith('$') && !val" :key="$key">{{ validation.$params[$key] | displayError }}</div>
+        <component :is="view" :field="field" :placeholder="field.field_name" :transparent="transparent" :read-only="readOnly" :model="model" @set-value="(val) => { $emit('set-value', val) }" :validation="validation"></component>
+    </div>
+</template>
+
+<script>
+    import FormMixin from '../mixins/Form'
+
+    export default {
+        mixins: [FormMixin],
+    }
+</script>

--- a/src/components/FormRow.vue
+++ b/src/components/FormRow.vue
@@ -2,38 +2,18 @@
     <tr>
         <td class="wide top aligned" :class="labelClasses">{{ field.field_name }}</td>
         <td class="wide" :class="inputClasses">
-            <component :is="view" :field="field" :placeholder="field.field_name" :transparent="transparent" :read-only="readOnly" :model="model" @set-value="(val) => { $emit('set-value', val) }"></component>
+            <component :is="view" :field="field" :placeholder="field.field_name" :transparent="transparent" :read-only="readOnly" :model="model" @set-value="(val) => { $emit('set-value', val) }" :validation="validation"></component>
         </td>
     </tr>
 </template>
 
 <script>
-    import CroudText from './fields/Text'
-    import Number from './fields/Number'
-    import MultiCheckbox from './fields/MultiCheckbox'
-    import CroudTextarea from './fields/Textarea'
-    import CroudSelect from './fields/Select'
-    import SearchSelect from './fields/SearchSelect'
-    import CroudRadio from './fields/Radio'
-    import SortCode from './fields/SortCode'
-    import General from './fields/General'
+    import FormMixin from '../mixins/Form'
 
     export default {
-        model: {
-            prop: 'model',
-            event: 'set-value',
-        },
+        mixins: [FormMixin],
 
         props: {
-            model: {
-                required: true,
-            },
-            field: {
-                required: true,
-            },
-            readOnly: {
-                default: false,
-            },
             columnWidths: {
                 default() {
                     return {
@@ -57,30 +37,10 @@
             inputClasses() {
                 const classes = {}
                 classes[this.columnWidths.input] = true
+                classes.error = this.validation.$error
 
                 return classes
             },
-            view() {
-                if (['select', 'radio', 'textarea', 'text'].indexOf(this.field.field_type) !== -1) {
-                    return `croud-${this.field.field_type}`
-                }
-                if (['search-select', 'number', 'multi-checkbox', 'sort-code'].indexOf(this.field.field_type) !== -1) {
-                    return this.field.field_type
-                }
-                return 'general'
-            },
-        },
-
-        components: {
-            Number,
-            CroudText,
-            CroudTextarea,
-            MultiCheckbox,
-            CroudSelect,
-            CroudRadio,
-            General,
-            SortCode,
-            SearchSelect,
         },
     }
 </script>

--- a/src/croud-forms.js
+++ b/src/croud-forms.js
@@ -1,10 +1,12 @@
 const FormRow = require('./components/FormRow.vue')
+const FormField = require('./components/FormField.vue')
 const DateTime = require('./components/fields/DateTime.vue')
 const Date = require('./components/fields/Date.vue')
 const Time = require('./components/fields/Time.vue')
 
 module.exports = {
     install(Vue) {
+        Vue.component('croud-form-field', FormField)
         Vue.component('croud-form-row', FormRow)
         Vue.component('croud-date-time', DateTime)
         Vue.component('croud-date', Date)

--- a/src/mixins/Form.js
+++ b/src/mixins/Form.js
@@ -1,0 +1,82 @@
+import CroudText from '../components/fields/Text'
+import Number from '../components/fields/Number'
+import MultiCheckbox from '../components/fields/MultiCheckbox'
+import CroudTextarea from '../components/fields/Textarea'
+import CroudSelect from '../components/fields/Select'
+import SearchSelect from '../components/fields/SearchSelect'
+import CroudRadio from '../components/fields/Radio'
+import SortCode from '../components/fields/SortCode'
+import General from '../components/fields/General'
+
+export default {
+    model: {
+        prop: 'model',
+        event: 'set-value',
+    },
+
+    props: {
+        model: {
+            required: true,
+        },
+        field: {
+            required: true,
+        },
+        readOnly: {
+            default: false,
+        },
+        transparent: {
+            default: false,
+        },
+        validation: {
+            default() {
+                return {}
+            },
+        },
+    },
+
+    computed: {
+        inputClasses() {
+            const classes = {}
+            classes.error = this.validation.$error
+
+            return classes
+        },
+        view() {
+            if (['select', 'radio', 'textarea', 'text'].indexOf(this.field.field_type) !== -1) {
+                return `croud-${this.field.field_type}`
+            }
+            if (['search-select', 'number', 'multi-checkbox', 'sort-code'].indexOf(this.field.field_type) !== -1) {
+                return this.field.field_type
+            }
+            return 'general'
+        },
+    },
+
+    components: {
+        Number,
+        CroudText,
+        CroudTextarea,
+        MultiCheckbox,
+        CroudSelect,
+        CroudRadio,
+        General,
+        SortCode,
+        SearchSelect,
+    },
+
+    filters: {
+        displayError(error) {
+            if (error.msg) return error.msg
+
+            switch (error.type) {
+            case 'numeric':
+                return 'Must be a numeric value'
+            case 'minLength':
+                return `Must be atleast ${error.min} characters long`
+
+            default:
+                return error
+            }
+        },
+    },
+}

--- a/src/mixins/Input.js
+++ b/src/mixins/Input.js
@@ -24,5 +24,17 @@ module.exports = {
         readOnly: {
             default: false,
         },
+
+        validation: {
+            required: true,
+        },
+    },
+
+    watch: {
+        value() {
+            if (this.validation.$touch) {
+                this.validation.$touch()
+            }
+        },
     },
 }


### PR DESCRIPTION
This is a proposal to add validation to croud-forms.

This allows vuelidate objects to be passed to the field or row, with this kind of markup

```html
<div class="ui form">
    <div v-for="field in fields" is='croud-form-field' v-model="user[field.key]" :validation="$v.user[field.key] || {}" :field="field" :key="field.key"></div>
</div>
```
And this should work with the standard vuelidate validation declarations.
```js
validations: {
    user: {
        name: {
            required,
            minLength: minLength(4),
        },
        other: {
            required,
            numeric,
        },
    },
},
```

The only problem I found with vuelidate is that it doesn't handle validation messages. Indeed the author seems to be behaving deliberately [obtuse](https://github.com/monterail/vuelidate/issues/3). Which is why I have added [this filter](https://github.com/CroudSupport/croud-forms/compare/vue2...vuelidate?expand=1#diff-377739b6801834dcef2ce36cd7445ebeR68) for formatting error messages, it only handles a few cases at the moment but it seems fairly robust and can probably even by called from a DB in the future.

There isn't any breaking changes here, but it will probably be worth testing this branch on an existing project before merging.

Cheers
Brock