### PR TITLE
Form builder imporvements, add error suppression and field classes

### DIFF
--- a/src/components/Example.vue
+++ b/src/components/Example.vue
@@ -86,11 +86,14 @@ export default {
                             class: 'two fields',
                             children: [
                                 {
+                                    class: 'four wide',
                                     field_name: 'Text-Input',
                                     field_type: 'text',
                                     field_slug: 'textInput',
+                                    suppressValidationErrors: true,
                                 },
                                 {
+                                    class: 'twelve wide',
                                     field_name: 'Text-Area',
                                     field_type: 'textarea',
                                     field_slug: 'textArea',

--- a/src/components/FormBuilder.vue
+++ b/src/components/FormBuilder.vue
@@ -57,7 +57,7 @@
                         },
                     },
 
-                    // class: field.class,
+                    class: field.class,
                 })
             },
 

--- a/src/components/FormBuilder.vue
+++ b/src/components/FormBuilder.vue
@@ -13,6 +13,11 @@
                 default: false,
             },
 
+            suppressValidationErrors: {
+                type: Boolean,
+                default: false,
+            },
+
             validations: {
                 type: Object,
                 default() {
@@ -43,6 +48,7 @@
                         model: this.value[field.field_slug],
                         readOnly: this.readOnly || field.readOnly,
                         validation: this.validations[field.field_slug] || {},
+                        suppressValidationErrors: this.suppressValidationErrors || field.suppressValidationErrors,
                     },
 
                     on: {
@@ -50,6 +56,8 @@
                             this.value[field.field_slug] = val
                         },
                     },
+
+                    // class: field.class,
                 })
             },
 

--- a/src/components/FormField.vue
+++ b/src/components/FormField.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="ui field" :class="inputClasses">
         <label>{{ field.field_name }}</label>
-        <div class="" v-for="(val, $key) in validation" v-if="validation.$dirty && !$key.startsWith('$') && !val" :key="$key">{{ validation.$params[$key] | displayError }}</div>
+        <div class="" v-for="(val, $key) in validation" v-if="!suppressValidationErrors && validation.$dirty && !$key.startsWith('$') && !val" :key="$key">{{ validation.$params[$key] | displayError }}</div>
         <component :is="view" :field="field" :placeholder="field.field_name" :transparent="transparent" :read-only="readOnly" :model="model" @set-value="(val) => { $emit('set-value', val) }" :validation="validation"></component>
     </div>
 </template>

--- a/src/mixins/Form.js
+++ b/src/mixins/Form.js
@@ -34,6 +34,10 @@ export default {
                 return {}
             },
         },
+        suppressValidationErrors: {
+            type: Boolean,
+            default: false,
+        },
     },
 
     computed: {


### PR DESCRIPTION
This allows you to pass a class key through with the field object.
You can also hide validation errors on both a form and field level.
- You can pass the :suppress-validation-errors="true" to hide all errors messages in the forms
- You can add a suppressValidationErrors key to the field object to hide a specific error