### PR TITLE
Custom render method

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,35 @@ export default {
 }
 
 ```
+
+### Custom components
+If you need to create a more complicated form field than this package provides, you can add pass a [render method](https://vuejs.org/v2/guide/render-function.html) through to the form builder. If you want to to use a custom component, you will need to globally register it before using it in the render method.
+
+```js
+// Globally register custom component
+Vue.component('test-component', {
+    template: '<div>hello world</div>',
+})
+...
+// Form builder config
+{
+  field_name: 'Test Component',
+  field_type: 'text',
+  field_slug: 'custom',
+  render: (h) => h('div', {
+    class: 'ui field',
+  }, [
+    h('label', 'Test Component'),
+    h('test-component'),
+  ]),
+},
+```
+
+Which will produce the following markup
+
+```html
+<div class="ui field">
+  <label>Test Component</label>
+  <div>hello world</div>
+</div>
+```

--- a/src/components/Example.vue
+++ b/src/components/Example.vue
@@ -32,6 +32,9 @@ import { required, minLength, numeric } from 'vuelidate/lib/validators'
 import CroudForms from '../croud-forms'
 
 Vue.use(CroudForms)
+Vue.component('test-component', {
+    template: '<div>hello world</div>',
+})
 
 export default {
     mixins: [validationMixin],
@@ -74,6 +77,17 @@ export default {
             dateData: moment(),
             timeData: moment(),
             contactFields: [
+                {
+                    field_name: 'Test Component',
+                    field_type: 'text',
+                    field_slug: 'custom',
+                    render: (h) => h('div', {
+                        class: 'ui field',
+                    }, [
+                        h('label', 'Test Component'),
+                        h('test-component'),
+                    ]),
+                },
                 {
                     field_name: 'Text-Input',
                     field_type: 'text',

--- a/src/components/FormBuilder.vue
+++ b/src/components/FormBuilder.vue
@@ -42,6 +42,7 @@
 
         methods: {
             buildNode(h, field) {
+                if (field.render) return field.render(h)
                 return h('croud-form-field', {
                     props: {
                         field,


### PR DESCRIPTION
Allow user to define a custom render method for a form builder field. This will accept a [Vue render method](https://vuejs.org/v2/guide/render-function.html) 

If you want to use a custom component you will need to globally register it before targeting it in your render method.

```js
// Globally register new component
Vue.component('test-component', {
    template: '<div>hello world</div>',
})
...
// Form builder config
{
  field_name: 'Test Component',
  field_type: 'text',
  field_slug: 'custom',
  render: (h) => h('div', {
    class: 'ui field',
  }, [
    h('label', 'Test Component'),
    h('test-component'),
  ]),
},
```

Which will produce the following markup
```html
<div class="ui field">
  <label>Test Component</label>
  <div>hello world</div>
</div>
```